### PR TITLE
Helps to run via php vendor/bin/autoroute-dump.php

### DIFF
--- a/bin/autoroute-dump.php
+++ b/bin/autoroute-dump.php
@@ -1,7 +1,18 @@
 <?php
 use AutoRoute\AutoRoute;
 
-$autoload = require dirname(__DIR__) . '/vendor/autoload.php';
+$autoload = '';
+
+$autoloadFiles = [
+    dirname(__DIR__) . '/vendor/autoload.php',
+    dirname(dirname(dirname(__DIR__))) . '/autoload.php'
+];
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        $autoload = require $autoloadFile;
+        break;
+    }
+}
 
 $options = getopt('', ['base-url:', 'ignore-params:', 'method:', 'suffix:', 'word-separator:'], $optind);
 


### PR DESCRIPTION
I was struggling to find the exact usage of this though.

Found some interesting issues like 

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to AutoRoute\Actions::actionExists() must be of the type string, boolean given, called in /home/chirakkal/projects/vendor/pmjones/auto-route/src/Actions.php on line 205 and defined in /home/chirakkal/projects/vendor/pmjones/auto-route/src/Actions.php:166
Stack trace:
#0 /home/chirakkal/projects/vendor/pmjones/auto-route/src/Actions.php(205): AutoRoute\Actions->actionExists(false, '\\vendor\\pmjones...')
#1 /home/chirakkal/projects/vendor/pmjones/auto-route/src/Dumper.php(46): AutoRoute\Actions->fileToClass('vendor/pmjones/...')
#2 /home/chirakkal/projects/vendor/pmjones/auto-route/src/Dumper.php(27): AutoRoute\Dumper->getClassesFromFiles(Array)
#3 /home/chirakkal/projects/vendor/pmjones/auto-route/bin/autoroute-dump.php(46): AutoRoute\Dumper->dumpRoutes()
#4 {main}
  thrown in /home/chirakkal/projects/vendor/pmjones/auto-route/src/Actions.php on line 166
```

and last I found I can only pass the namespace and source directory only last and not before using options.

```
php vendor/bin/autoroute-dump.php --ignore-params true App ./src/Http
```

Below will fail. May be you are aware of it.

```
php vendor/bin/autoroute-dump.php  App ./src/Http --ignore-params true
```