### PR TITLE
Fix protected property IDE hint in Route.php

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -13,7 +13,7 @@ namespace AutoRoute;
 /**
  * @property-read string $class
  * @property-read string $method
- * @property-read array $args
+ * @property-read array $params
  */
 class Route
 {


### PR DESCRIPTION
Fix $route->params "member has protected access" notice in IDE.
Comment notation should mention $params instead of $args