### PR TITLE
Exposed autoroute-create.php script.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "phpstan/phpstan": "^0.12.82"
     },
     "bin": [
-        "bin/autoroute-dump.php"
+        "bin/autoroute-dump.php",
+        "bin/autoroute-create.php"
     ],
     "scripts": {
         "test": "./vendor/bin/phpunit",


### PR DESCRIPTION
Now in my consumer project I can have this:
```JSON
{
    "autoload": {
        "psr-4": {
            "Mocks\\Pam\\": "./mocks/pam/",
            "Utils\\": "./utils/"
        }
    },
    "require": {
        "symfony/http-foundation": "^6.2",
        "pmjones/auto-route": "^2.0"
    },
    "scripts": {
        "pam-routes": "autoroute-dump.php --word-separator=_ Mocks\\\\Pam ./mocks/pam/",
        "pam-new-post": "autoroute-create.php --word-separator=_ Mocks\\\\Pam ./mocks/pam/ POST $1",
        "pam-new-get": "autoroute-create.php --word-separator=_ Mocks\\\\Pam ./mocks/pam/ GET $1" 
   }
}
```